### PR TITLE
log UUID of the Dependency Track project

### DIFF
--- a/dtrackauditor/dtrackauditor.py
+++ b/dtrackauditor/dtrackauditor.py
@@ -96,6 +96,7 @@ def main():
         print('Auto mode ON')
         Auditor.read_upload_bom(dt_server, dt_api_key, project_name, version, filename, True, wait=args.wait)
         project_uuid = Auditor.get_project_with_version_id(dt_server, dt_api_key, project_name, version)
+        print(f'Project UUID: {project_uuid}')
         if project_uuid:
             Auditor.check_policy_violations(dt_server, dt_api_key, project_uuid)
             Auditor.check_vulnerabilities(dt_server, dt_api_key, project_uuid, args.rules, show_details)


### PR DESCRIPTION
This change prints the project's UUID.

By including the project's UUID in the console output, a direct link to the project in Dependency Track can be easily constructed. This link can be, for example, added as a note to a merge request, where developers can triage issues found.