### PR TITLE
Fix running from a git checkout (with two sources in same dir)

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,6 @@ docker pull thinksabin/dtrackauditor:latest
 Git
 git clone https://github.com/thinksabin/DTrackAuditor.git
 ```
-Note: if you are doing git clone and executing dtrackauditor.py then do correct the import of Auditor or
-place the dtrackauditor.py file outside dtrackauditor folder. Let me know if there is proper way to handle this. :)
 
 ### Usage
 

--- a/dtrackauditor/dtrackauditor.py
+++ b/dtrackauditor/dtrackauditor.py
@@ -4,7 +4,11 @@ import os
 import sys
 import argparse
 
-from dtrackauditor.auditor import Auditor
+try:
+    from dtrackauditor.auditor import Auditor
+except ModuleNotFoundError:
+    # Same dir (running from Git checkout)?..
+    from auditor import Auditor
 
 DTRACK_SERVER = os.environ.get('DTRACK_SERVER')
 DTRACK_API_KEY = os.environ.get('DTRACK_API_KEY')


### PR DESCRIPTION
Original code failed to run from a checkout, even the README said as much:
````
:; python3 ./dtrackauditor/dtrackauditor.py 
Traceback (most recent call last):
  File "...\DTrackAuditor\dtrackauditor\dtrackauditor.py", line 8, in <module>
    from dtrackauditor.auditor import Auditor
ModuleNotFoundError: No module named 'dtrackauditor.auditor'; 'dtrackauditor' is not a package
````

A little trick in this PR allows it to run (both from the subdirectory and if moved to checkout root, as was done before).

NOTE: This PR covers one of several features we needed to add or fix, to simplify the targeted review. It is recommended to merge in fact the PR #29 (which combines this one and some others) in one simple swoop :)