### PR TITLE
Introduce AuditorException class to avoid hard sys.exit() …

### DIFF
--- a/dtrackauditor/dtrackauditor.py
+++ b/dtrackauditor/dtrackauditor.py
@@ -5,6 +5,7 @@ import sys
 import argparse
 
 from dtrackauditor.auditor import Auditor
+from dtrackauditor.auditor import AuditorException
 
 DTRACK_SERVER = os.environ.get('DTRACK_SERVER')
 DTRACK_API_KEY = os.environ.get('DTRACK_API_KEY')
@@ -46,13 +47,11 @@ def parse_cmd_args():
     if args.url is None:
         args.url = DTRACK_SERVER
     if not isinstance(args.url, str) or len(args.url) == 0:
-        print('DependencyTrack server URL is required. Set env $DTRACK_SERVER or use --url.eg: http://dtrack.my.local')
-        sys.exit(1)
+        raise AuditorException('DependencyTrack server URL is required. Set env $DTRACK_SERVER or use --url.eg: http://dtrack.my.local')
     if args.apikey is None:
         args.apikey = DTRACK_API_KEY
     if not isinstance(args.apikey, str) or len(args.apikey) == 0:
-        print('DependencyTrack api key is required. Set Env $DTRACK_API_KEY or use --apikey.')
-        sys.exit(1)
+        raise AuditorException('DependencyTrack api key is required. Set Env $DTRACK_API_KEY or use --apikey.')
     if args.rules is None:
         args.rules = []
     else:
@@ -66,6 +65,10 @@ def parse_cmd_args():
     return args
 
 def main():
+    # Instead of raising an exception that may be caught by code,
+    # print the message and exit (legacy behavior for the CLI tool):
+    AuditorException.INSTANT_EXIT = True
+
     args = parse_cmd_args()
     dt_server = args.url.strip()
     if dt_server[-1] == '/':
@@ -79,14 +82,12 @@ def main():
         sys.exit(0)
 
     if show_details not in ['TRUE', 'FALSE', 'ALL']:
-        print('Issue with an option --showdetails. Please check the accepted values.')
-        sys.exit(1)
+        raise AuditorException('Issue with an option --showdetails. Please check the accepted values.')
     if args.project is None or \
        len(args.project) == 0 or \
        args.version is None or \
        len(args.version) == 0:
-        print('Project Name (-p) and Version (-v) are required. Check help --help.')
-        sys.exit(1)
+        raise AuditorException('Project Name (-p) and Version (-v) are required. Check help --help.')
 
     project_name = args.project.strip()
     version = args.version.strip()


### PR DESCRIPTION
…when using auditor.py as a library

Until now, the use of that module as a library could break the calling script. With this PR, the consumer has a chance to react differently.

Examples:
* default behavior for the CLI tool remains to compactly print an error and exit:
````
$ python dtrackauditor/dtrackauditor.py -p xxx -v xxx
Provided project name and version:  xxx xxx
Uploading ../bom.xml ...
C:\<...>\DTrackAuditor\dtrackauditor\..\bom.xml not found !
````

* proper behavior for the library (when `AuditorException.INSTANT_EXIT = True` is set by caller):
````
$ python dtrackauditor/dtrackauditor.py -p xxx -v xxx
Provided project name and version:  xxx xxx
Uploading ../bom.xml ...
Traceback (most recent call last):
  File "C:\<...>\DTrackAuditor\dtrackauditor\dtrackauditor.py", line 129, in <module>
    main()
  File "C:\<...>\DTrackAuditor\dtrackauditor\dtrackauditor.py", line 126, in main
    Auditor.read_upload_bom(dt_server, dt_api_key, project_name, version, filename, False, wait=args.wait, verify=args.certchain)
  File "C:\<...>\DTrackAuditor\dtrackauditor\auditor.py", line 187, in read_upload_bom
    raise AuditorException(f"{filename} not found !")
auditor.AuditorException: C:\<...>\DTrackAuditor\dtrackauditor\..\bom.xml not found !
````

NOTE: Currently the default behavior remains as it was (defaulting `INSTANT_EXIT=True` in the `AuditorException` class), aiming for the principle of least surprise for existing users. Ideally a release heads-up should be made about the tool behaving as it did, but the library changing to exceptions by default, and trowing that switch to `False` in the class. The CLI script sets `True` explicitly already.
* https://github.com/thinksabin/DTrackAuditor/compare/master...jimklimov:DTrackAuditor:use-exceptions?expand=1#diff-f9984f110542a151439be91eaac59153b53aa189c0f811134c3f5a879a943b78R16-R21
* https://github.com/thinksabin/DTrackAuditor/compare/master...jimklimov:DTrackAuditor:use-exceptions?expand=1#diff-b8ab022ff39ce75c1c1c9e8ccdc6ea051c24282a3feb4af4ac0bb32c26d5e4f0R68-R70

NOTE: This PR covers one of several features we needed to add or fix, to simplify the targeted review. It is recommended to merge in fact the PR #29 (which combines this one and some others) in one simple swoop :)