### PR TITLE
Support HTTPS requests with corporate CA cert chain (or self-signed)

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,13 @@ If environment variable for `DTRACK_SERVER` and `DTRACK_API_KEY` are present the
 python3 dtrackauditor.py  -p myweb -v 1.0.0 -a
 ```
 
+If your DependencyTrack server is exposed through an HTTPS listener (e.g.
+using an nginx or apache web-server as a reverse proxy for the UI and API
+servers), and if this setup uses self-signed certificates or those issued by
+a private (corporate) Certificate Authority, you may benefit from passing
+a path to PEM file with the trust chain using `DTRACK_SERVER_CERTCHAIN`
+environment variable or the `-C`/`--certchain` command-line argument.
+
 #### Vulnerability Rules
 
 Auto mode for CI/CD with support for rules.

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ servers), and if this setup uses self-signed certificates or those issued by
 a private (corporate) Certificate Authority, you may benefit from passing
 a path to PEM file with the trust chain using `DTRACK_SERVER_CERTCHAIN`
 environment variable or the `-C`/`--certchain` command-line argument.
+Such argument may also be `none` to trust any HTTPS server blindly.
 
 #### Vulnerability Rules
 

--- a/dtrackauditor/auditor.py
+++ b/dtrackauditor/auditor.py
@@ -20,7 +20,7 @@ class Auditor:
         return status == False
 
     @staticmethod
-    def poll_bom_token_being_processed(host, key, bom_token, verify=False):
+    def poll_bom_token_being_processed(host, key, bom_token, verify=True):
         print("Waiting for bom to be processed on dt server ...")
         print(f"Processing token uuid is {bom_token}")
         url = host + API_BOM_TOKEN+'/{}'.format(bom_token)
@@ -45,7 +45,7 @@ class Auditor:
         }
 
     @staticmethod
-    def get_project_policy_violations(host, key, project_id, verify=False):
+    def get_project_policy_violations(host, key, project_id, verify=True):
         url = host + API_POLICY_VIOLATIONS % project_id
         headers = {
             "content-type": "application/json",
@@ -58,7 +58,7 @@ class Auditor:
         return json.loads(r.text)
 
     @staticmethod
-    def check_vulnerabilities(host, key, project_uuid, rules, show_details, verify=False):
+    def check_vulnerabilities(host, key, project_uuid, rules, show_details, verify=True):
         project_findings = Auditor.get_project_findings(host, key, project_uuid, verify=verify)
         severity_scores = Auditor.get_project_finding_severity(project_findings)
         print(severity_scores)
@@ -85,7 +85,7 @@ class Auditor:
         print('Vulnerability audit resulted in no violations.')
 
     @staticmethod
-    def check_policy_violations(host, key, project_uuid, verify=False):
+    def check_policy_violations(host, key, project_uuid, verify=True):
         policy_violations = Auditor.get_project_policy_violations(host, key, project_uuid, verify=verify)
         if not isinstance(policy_violations, list):
             print("Invalid response when fetching policy violations.")
@@ -117,7 +117,7 @@ class Auditor:
         return severity_count
 
     @staticmethod
-    def get_project_findings(host, key, project_id, verify=False):
+    def get_project_findings(host, key, project_id, verify=True):
         url = host + API_PROJECT_FINDING + '/{}'.format(project_id)
         headers = {
             "content-type": "application/json",
@@ -130,7 +130,7 @@ class Auditor:
         return json.loads(r.text)
 
     @staticmethod
-    def get_project_without_version_id(host, key, project_name, version, verify=False):
+    def get_project_without_version_id(host, key, project_name, version, verify=True):
         url = host + API_PROJECT
         headers = {
             "content-type": "application/json",
@@ -147,7 +147,7 @@ class Auditor:
                 return _project_id
 
     @staticmethod
-    def get_project_with_version_id(host, key, project_name, version, verify=False):
+    def get_project_with_version_id(host, key, project_name, version, verify=True):
         project_name = project_name
         version = version
         url = host + API_PROJECT_LOOKUP + '?name={}&version={}'.format(project_name, version)
@@ -163,7 +163,7 @@ class Auditor:
         return response_dict.get('uuid')
 
     @staticmethod
-    def read_upload_bom(host, key, project_name, version, filename, auto_create, wait=False, verify=False):
+    def read_upload_bom(host, key, project_name, version, filename, auto_create, wait=False, verify=True):
         print(f"Uploading {filename} ...")
         filename = filename if Path(filename).exists() else str(Path(__file__).parent / filename)
 
@@ -203,7 +203,7 @@ class Auditor:
             Auditor.poll_bom_token_being_processed(host, key, bom_token)
 
     @staticmethod
-    def get_dependencytrack_version(host, key, verify=False):
+    def get_dependencytrack_version(host, key, verify=True):
         print("getting version of OWASP DependencyTrack")
         print(host, key)
         url = host + API_VERSION

--- a/dtrackauditor/auditor.py
+++ b/dtrackauditor/auditor.py
@@ -14,14 +14,13 @@ API_POLICY_VIOLATIONS = '/api/v1/violation/project/%s'
 API_VERSION = '/api/version'
 
 class Auditor:
-
     @staticmethod
     def poll_response(response):
         status = json.loads(response.text).get('processing')
         return status == False
 
     @staticmethod
-    def poll_bom_token_being_processed(host, key, bom_token):
+    def poll_bom_token_being_processed(host, key, bom_token, verify=False):
         print("Waiting for bom to be processed on dt server ...")
         print(f"Processing token uuid is {bom_token}")
         url = host + API_BOM_TOKEN+'/{}'.format(bom_token)
@@ -30,7 +29,7 @@ class Auditor:
             "X-API-Key": key
         }
         result = polling.poll(
-            lambda: requests.get(url, headers=headers),
+            lambda: requests.get(url, headers=headers, verify=verify),
             step=5,
             poll_forever=True,
             check_success=Auditor.poll_response
@@ -46,21 +45,21 @@ class Auditor:
         }
 
     @staticmethod
-    def get_project_policy_violations(host, key, project_id):
+    def get_project_policy_violations(host, key, project_id, verify=False):
         url = host + API_POLICY_VIOLATIONS % project_id
         headers = {
             "content-type": "application/json",
             "X-API-Key": key
         }
-        r = requests.get(url, headers=headers)
+        r = requests.get(url, headers=headers, verify=verify)
         if r.status_code != 200:
             print(f"Cannot get policy violations: {r.status_code} {r.reason}")
             return {}
         return json.loads(r.text)
 
     @staticmethod
-    def check_vulnerabilities(host, key, project_uuid, rules, show_details):
-        project_findings = Auditor.get_project_findings(host, key, project_uuid)
+    def check_vulnerabilities(host, key, project_uuid, rules, show_details, verify=False):
+        project_findings = Auditor.get_project_findings(host, key, project_uuid, verify=verify)
         severity_scores = Auditor.get_project_finding_severity(project_findings)
         print(severity_scores)
 
@@ -86,8 +85,8 @@ class Auditor:
         print('Vulnerability audit resulted in no violations.')
 
     @staticmethod
-    def check_policy_violations(host, key, project_uuid):
-        policy_violations = Auditor.get_project_policy_violations(host, key, project_uuid)
+    def check_policy_violations(host, key, project_uuid, verify=False):
+        policy_violations = Auditor.get_project_policy_violations(host, key, project_uuid, verify=verify)
         if not isinstance(policy_violations, list):
             print("Invalid response when fetching policy violations.")
             sys.exit(1)
@@ -118,26 +117,26 @@ class Auditor:
         return severity_count
 
     @staticmethod
-    def get_project_findings(host, key , project_id):
+    def get_project_findings(host, key, project_id, verify=False):
         url = host + API_PROJECT_FINDING + '/{}'.format(project_id)
         headers = {
             "content-type": "application/json",
             "X-API-Key": key
         }
-        r = requests.get(url, headers=headers)
+        r = requests.get(url, headers=headers, verify=verify)
         if r.status_code != 200:
             print(f"Cannot get project findings: {r.status_code} {r.reason}")
             return {}
         return json.loads(r.text)
 
     @staticmethod
-    def get_project_without_version_id(host, key, project_name, version):
+    def get_project_without_version_id(host, key, project_name, version, verify=False):
         url = host + API_PROJECT
         headers = {
             "content-type": "application/json",
             "X-API-Key": key
         }
-        r = requests.get(url, headers=headers)
+        r = requests.get(url, headers=headers, verify=verify)
         if r.status_code != 200:
             print("Cannot get project without version id: {r.status_code} {r.reason}")
             return None
@@ -148,7 +147,7 @@ class Auditor:
                 return _project_id
 
     @staticmethod
-    def get_project_with_version_id(host, key, project_name, version):
+    def get_project_with_version_id(host, key, project_name, version, verify=False):
         project_name = project_name
         version = version
         url = host + API_PROJECT_LOOKUP + '?name={}&version={}'.format(project_name, version)
@@ -156,7 +155,7 @@ class Auditor:
             "content-type": "application/json",
             "X-API-Key": key
         }
-        res = requests.get(url, headers=headers)
+        res = requests.get(url, headers=headers, verify=verify)
         if res.status_code != 200:
             print(f"Cannot get project id: {res.status_code} {res.reason}")
             return ""
@@ -164,7 +163,7 @@ class Auditor:
         return response_dict.get('uuid')
 
     @staticmethod
-    def read_upload_bom(host, key, project_name, version, filename, auto_create, wait=False):
+    def read_upload_bom(host, key, project_name, version, filename, auto_create, wait=False, verify=False):
         print(f"Uploading {filename} ...")
         filename = filename if Path(filename).exists() else str(Path(__file__).parent / filename)
 
@@ -194,7 +193,7 @@ class Auditor:
             "content-type": "application/json",
             "X-API-Key": key
         }
-        r = requests.put(host + API_BOM_UPLOAD, data=json.dumps(payload), headers=headers)
+        r = requests.put(host + API_BOM_UPLOAD, data=json.dumps(payload), headers=headers, verify=verify)
         if r.status_code != 200:
             print(f"Cannot upload {filename}: {r.status_code} {r.reason}")
             sys.exit(1)
@@ -204,7 +203,7 @@ class Auditor:
             Auditor.poll_bom_token_being_processed(host, key, bom_token)
 
     @staticmethod
-    def get_dependencytrack_version(host, key):
+    def get_dependencytrack_version(host, key, verify=False):
         print("getting version of OWASP DependencyTrack")
         print(host, key)
         url = host + API_VERSION
@@ -213,7 +212,7 @@ class Auditor:
             "X-API-Key": key.strip()
         }
         print(url)
-        res = requests.get(url, headers=headers)
+        res = requests.get(url, headers=headers, verify=verify)
         if res.status_code != 200:
             print(f"Cannot connect to the server {res.status_code} {res.reason}")
             return ""

--- a/dtrackauditor/dtrackauditor.py
+++ b/dtrackauditor/dtrackauditor.py
@@ -8,6 +8,8 @@ from dtrackauditor.auditor import Auditor
 
 DTRACK_SERVER = os.environ.get('DTRACK_SERVER')
 DTRACK_API_KEY = os.environ.get('DTRACK_API_KEY')
+DTRACK_SERVER_CERTCHAIN = os.environ.get('DTRACK_SERVER_CERTCHAIN')
+""" Optional TLS certificate chain (server, CA) can be provided here """
 
 DEFAULT_VERSION = '1.0.0'
 DEFAULT_FILENAME = '../bom.xml'
@@ -22,6 +24,8 @@ def parse_cmd_args():
                         help=' * url of dependencytrack host. eg. http://dtrack.abc.local:8080. OR set env $DTRACK_SERVER')
     parser.add_argument('-k', '--apikey', type=str,
                         help=' * api key of dependencytrack host. eg. adfadfe343g. OR set env $DTRACK_API_KEY')
+    parser.add_argument('-C', '--certchain', type=str,
+                        help=' * path to file with cert chain of dependencytrack host (if HTTPS and not using a well-known CA). OR set env $DTRACK_SERVER_CERTCHAIN')
     parser.add_argument('-p', '--project', type=str,
                         help=' * project name to be used in dependencytrack.eg: mywebapp. *')
     parser.add_argument('-v', '--version', type=str,
@@ -53,6 +57,20 @@ def parse_cmd_args():
     if not isinstance(args.apikey, str) or len(args.apikey) == 0:
         print('DependencyTrack api key is required. Set Env $DTRACK_API_KEY or use --apikey.')
         sys.exit(1)
+    if args.certchain is None:
+        args.certchain = DTRACK_SERVER_CERTCHAIN
+    if args.url.lower().startswith("https://"):
+        if not isinstance(args.certchain, str) or len(args.certchain) == 0:
+            print('DependencyTrack server is HTTPS but no path to file with cert chain was provided (may be required if not using a well-known CA). Set Env $DTRACK_SERVER_CERTCHAIN or use --certchain if requests fail.')
+            # Ends up as "verify" argument to requests.get() et al:
+            args.certchain = False
+        else:
+            if not os.path.exists(args.certchain):
+                print('DependencyTrack server is HTTPS but specified path to file with cert chain is missing: %s' % args.certchain)
+                sys.exit(1)
+            if not os.path.isabs(args.certchain):
+                # Be sure to use the intended file even if we chdir() later in the program:
+                args.certchain = os.path.sep.join([os.getcwd(), args.certchain])
     if args.rules is None:
         args.rules = []
     else:
@@ -75,7 +93,7 @@ def main():
     show_details = args.showdetails.strip().upper()
 
     if args.getversion:
-        Auditor.get_dependencytrack_version(dt_server, dt_api_key)
+        Auditor.get_dependencytrack_version(dt_server, dt_api_key, verify=args.certchain)
         sys.exit(0)
 
     if show_details not in ['TRUE', 'FALSE', 'ALL']:
@@ -94,13 +112,13 @@ def main():
     print('Provided project name and version: ', project_name, version)
     if args.auto:
         print('Auto mode ON')
-        Auditor.read_upload_bom(dt_server, dt_api_key, project_name, version, filename, True, wait=args.wait)
-        project_uuid = Auditor.get_project_with_version_id(dt_server, dt_api_key, project_name, version)
+        Auditor.read_upload_bom(dt_server, dt_api_key, project_name, version, filename, True, wait=args.wait, verify=args.certchain)
+        project_uuid = Auditor.get_project_with_version_id(dt_server, dt_api_key, project_name, version, verify=args.certchain)
         if project_uuid:
-            Auditor.check_policy_violations(dt_server, dt_api_key, project_uuid)
-            Auditor.check_vulnerabilities(dt_server, dt_api_key, project_uuid, args.rules, show_details)
+            Auditor.check_policy_violations(dt_server, dt_api_key, project_uuid, verify=args.certchain)
+            Auditor.check_vulnerabilities(dt_server, dt_api_key, project_uuid, args.rules, show_details, verify=args.certchain)
     else:
-        Auditor.read_upload_bom(dt_server, dt_api_key, project_name, version, filename, False, wait=args.wait)
+        Auditor.read_upload_bom(dt_server, dt_api_key, project_name, version, filename, False, wait=args.wait, verify=args.certchain)
 
 if __name__ == '__main__':
    main()


### PR DESCRIPTION
Currently requests to HTTPS-protected Dependency-Track instances fail if the server uses a certificate not from a "well-known" CA (provided by OS or tediously added into its trust stores). 

This PR allows users to provide a custom file with the (complete! server->intermediateCA->rootCA) certificate chain needed to trust the server, using envvars or command line. Alternately, a `none` (`None`, `False`) may be specified instead of a filename to trust any HTTPS server lazily.

No-op for plain HTTP servers (e.g. default access to DT API server).

NOTE: This PR covers one of several features we needed to add or fix, to simplify the targeted review. It is recommended to merge in fact the PR #29 (which combines this one and some others) in one simple swoop :)