### PR TITLE
Enhance exceptions, logs, methods...

### DIFF
--- a/dtrackauditor/auditor.py
+++ b/dtrackauditor/auditor.py
@@ -389,7 +389,7 @@ class Auditor:
             return None
         except AuditorRESTAPIException as ex:
             if Auditor.DEBUG_VERBOSITY > 0:
-                print(f"Cannot get project without version id: {ex.result.status_code} {ex.result.reason}")
+                print(f"Cannot get project '{project_name}' '{version}' without version id: {ex.result.status_code} {ex.result.reason}")
             # TODO? raise AuditorRESTAPIException("Cannot get project without version id", r)
             return ""
 
@@ -416,7 +416,7 @@ class Auditor:
         res = requests.get(url, headers=headers, verify=verify)
         if res.status_code != 200:
             if Auditor.DEBUG_VERBOSITY > 0:
-                print(f"Cannot get project id: {res.status_code} {res.reason}")
+                print(f"Cannot get project '{project_name}' '{version}' id: {res.status_code} {res.reason}")
             # TODO? raise AuditorRESTAPIException("Cannot get project id", res)
             return ""
         response_dict = json.loads(res.text)

--- a/dtrackauditor/auditor.py
+++ b/dtrackauditor/auditor.py
@@ -22,12 +22,16 @@ class AuditorException(Exception):
     """ Instead of raising an exception that may be caught by code,
     print the message and exit (legacy behavior for the CLI tool) """
 
-    def __init__(self, message = "Dependency-Track Auditor did not pass a test"):
+    def __init__(self, message = "Dependency-Track Auditor did not pass a test", result = None):
         if AuditorException.INSTANT_EXIT:
             print(message)
             sys.exit(1)
 
         self.message = message
+
+        self.result = result
+        """ Result of an HTTP query which caused the exception, if any """
+
         super().__init__(self.message)
 
 class Auditor:

--- a/dtrackauditor/auditor.py
+++ b/dtrackauditor/auditor.py
@@ -164,6 +164,7 @@ class Auditor:
             else:
                 if Auditor.DEBUG_VERBOSITY > 2:
                     print(f"Deletion request for project uuid {project_uuid} failed: {result.status_code} {result.reason} => {result.text}")
+                # TODO? raise AuditorRESTAPIException(f"Deletion request for project uuid {project_uuid} failed, r)
 
         if wait:
             if Auditor.DEBUG_VERBOSITY > 2:
@@ -205,6 +206,7 @@ class Auditor:
         if r.status_code != 200:
             if Auditor.DEBUG_VERBOSITY > 0:
                 print(f"Cannot get policy violations: {r.status_code} {r.reason}")
+            # TODO? raise AuditorRESTAPIException("Cannot get policy violations", r)
             return {}
         return json.loads(r.text)
 
@@ -279,6 +281,7 @@ class Auditor:
         if r.status_code != 200:
             if Auditor.DEBUG_VERBOSITY > 0:
                 print(f"Cannot get project findings: {r.status_code} {r.reason}")
+            # TODO? raise AuditorRESTAPIException("Cannot get project findings", r)
             return {}
         return json.loads(r.text)
 
@@ -293,6 +296,7 @@ class Auditor:
         if r.status_code != 200:
             if Auditor.DEBUG_VERBOSITY > 0:
                 print("Cannot get project without version id: {r.status_code} {r.reason}")
+            # TODO? raise AuditorRESTAPIException("Cannot get project without version id", r)
             return None
         response_dict = json.loads(r.text)
         for project in response_dict:
@@ -313,6 +317,7 @@ class Auditor:
         if res.status_code != 200:
             if Auditor.DEBUG_VERBOSITY > 0:
                 print(f"Cannot get project id: {res.status_code} {res.reason}")
+            # TODO? raise AuditorRESTAPIException("Cannot get project id", res)
             return ""
         response_dict = json.loads(res.text)
         return response_dict.get('uuid')
@@ -375,7 +380,7 @@ class Auditor:
         }
         r = requests.put(host + API_BOM_UPLOAD, data=json.dumps(payload), headers=headers, verify=verify)
         if r.status_code != 200:
-            raise AuditorException(f"Cannot upload {filename}: {r.status_code} {r.reason}")
+            raise AuditorRESTAPIException(f"Cannot upload {filename}", r)
 
         bom_token = json.loads(r.text).get('token')
         if bom_token and wait:
@@ -473,7 +478,7 @@ class Auditor:
                 data=json.dumps({"name": "%s" % new_name}),
                 headers=headers, verify=verify)
             if r.status_code != 200:
-                raise AuditorException(f"Cannot rename {new_project_uuid}: {r.status_code} {r.reason}")
+                raise AuditorRESTAPIException(f"Cannot rename {new_project_uuid}", r)
 
         return new_project_uuid
 
@@ -512,7 +517,7 @@ class Auditor:
             host + API_PROJECT + '/{}'.format(project_id),
             data=json.dumps(payload), headers=headers, verify=verify)
         if r.status_code != 200:
-            raise AuditorException(f"Cannot modify project {project_id}: {r.status_code} {r.reason}")
+            raise AuditorRESTAPIException(f"Cannot modify project {project_id}", r)
 
         while wait:
             objPrj = Auditor.poll_project_uuid(host, key, project_id)
@@ -535,6 +540,7 @@ class Auditor:
         res = requests.get(url, headers=headers, verify=verify)
         if res.status_code != 200:
             print(f"Cannot connect to the server {res.status_code} {res.reason}")
+            # TODO? raise AuditorRESTAPIException("Cannot connect to the server", res)
             return ""
         response_dict = json.loads(res.text)
         if Auditor.DEBUG_VERBOSITY > 2:

--- a/dtrackauditor/auditor.py
+++ b/dtrackauditor/auditor.py
@@ -24,7 +24,7 @@ class AuditorException(Exception):
 
     def __init__(self, message = "Dependency-Track Auditor did not pass a test"):
         if AuditorException.INSTANT_EXIT:
-            print(message)
+            print("AuditorException.INSTANT_EXIT: " + message)
             sys.exit(1)
 
         self.message = message
@@ -36,9 +36,7 @@ class AuditorRESTAPIException(AuditorException):
 
     def __init__(self, message = "Dependency-Track Auditor had a REST API unexpected situation", result = None):
         if AuditorException.INSTANT_EXIT:
-            print(message)
-            if result is not None:
-                print(f"HTTP Result: {result.status_code} {result.reason}")
+            print("AuditorRESTAPIException.INSTANT_EXIT: " + AuditorRESTAPIException.stringify(message, result))
             sys.exit(1)
 
         self.result = result
@@ -46,17 +44,24 @@ class AuditorRESTAPIException(AuditorException):
 
         super().__init__(message)
 
-    def __str__(self):
-        s = f"${self.message}"
-        if self.result is not None:
-            s += ": {result.status_code} {result.reason}"
-            if self.result.text is None or len(self.result.text) == 0:
-                s += " <empty response content>"
-            elif len(self.result.text) < 128:
-                s += f" => {self.result.text}"
-            else:
-                s += f" <response content length is {len(self.result.text)}>"
+    @staticmethod
+    def stringify(message, result):
+        s = f"{message}"
+        try:
+            if result is not None:
+                s += f": HTTP-{result.status_code} {result.reason}"
+                if result.text is None or len(result.text) == 0:
+                    s += " <empty response content>"
+                elif len(result.text) < 128:
+                    s += f" => {result.text}"
+                else:
+                    s += f" <response content length is {len(result.text)}>"
+        except Exception as ignored:
+            pass
         return s
+
+    def __str__(self):
+        return AuditorRESTAPIException.stringify(self.message, self.result)
 
 class Auditor:
     DEBUG_VERBOSITY = 3

--- a/dtrackauditor/auditor.py
+++ b/dtrackauditor/auditor.py
@@ -98,6 +98,10 @@ class Auditor:
 
     @staticmethod
     def poll_bom_token_being_processed(host, key, bom_token, wait=True, verify=True):
+        assert (host is not None and host != "")
+        assert (key is not None and key != "")
+        assert (bom is not None and bom != "")
+
         if Auditor.DEBUG_VERBOSITY > 2:
             print("Waiting for bom to be processed on dt server ...")
         if Auditor.DEBUG_VERBOSITY > 3:
@@ -129,6 +133,10 @@ class Auditor:
         Checks if that info's 'uuid' matches (fails an assert()
         otherwise) and returns the object decoded from JSON.
         """
+        assert (host is not None and host != "")
+        assert (key is not None and key != "")
+        assert (project_uuid is not None and project_uuid != "")
+
         if Auditor.DEBUG_VERBOSITY > 2:
             print(f"Waiting for project uuid {project_uuid} to be reported by dt server ...")
         url = host + API_PROJECT + '/{}'.format(project_uuid)
@@ -160,6 +168,10 @@ class Auditor:
         Checks if that info's 'uuid' matches (fails an assert()
         otherwise) and returns the object decoded from JSON.
         """
+        assert (host is not None and host != "")
+        assert (key is not None and key != "")
+        assert (project_uuid is not None and project_uuid != "")
+
         if Auditor.DEBUG_VERBOSITY > 2:
             print(f"Deleting project uuid {project_uuid} (if present on dt server) ...")
         url = host + API_PROJECT + '/{}'.format(project_uuid)
@@ -205,6 +217,11 @@ class Auditor:
 
     @staticmethod
     def delete_project(host, key, project_name, version, wait=True, verify=True):
+        assert (host is not None and host != "")
+        assert (key is not None and key != "")
+        assert (project_name is not None and project_name != "")
+        assert (version is not None and version != "")
+
         if Auditor.DEBUG_VERBOSITY > 3:
             # Found UUID (if any) will be reported by the called method
             print(f"Querying for UUID of project to delete ('{project_name}' '{version}')...")
@@ -225,6 +242,10 @@ class Auditor:
 
     @staticmethod
     def get_project_policy_violations(host, key, project_id, verify=True):
+        assert (host is not None and host != "")
+        assert (key is not None and key != "")
+        assert (project_id is not None and project_id != "")
+
         url = host + API_POLICY_VIOLATIONS % project_id
         headers = {
             "content-type": "application/json",
@@ -240,6 +261,10 @@ class Auditor:
 
     @staticmethod
     def check_vulnerabilities(host, key, project_uuid, rules, show_details, verify=True):
+        assert (host is not None and host != "")
+        assert (key is not None and key != "")
+        assert (project_uuid is not None and project_uuid != "")
+
         project_findings = Auditor.get_project_findings(host, key, project_uuid, verify=verify)
         severity_scores = Auditor.get_project_finding_severity(project_findings)
         print(severity_scores)
@@ -268,6 +293,10 @@ class Auditor:
 
     @staticmethod
     def check_policy_violations(host, key, project_uuid, verify=True):
+        assert (host is not None and host != "")
+        assert (key is not None and key != "")
+        assert (project_uuid is not None and project_uuid != "")
+
         policy_violations = Auditor.get_project_policy_violations(host, key, project_uuid, verify=verify)
         if not isinstance(policy_violations, list):
             raise AuditorException("Invalid response when fetching policy violations.")
@@ -300,6 +329,10 @@ class Auditor:
 
     @staticmethod
     def get_project_findings(host, key, project_id, verify=True):
+        assert (host is not None and host != "")
+        assert (key is not None and key != "")
+        assert (project_id is not None and project_id != "")
+
         url = host + API_PROJECT_FINDING + '/{}'.format(project_id)
         headers = {
             "content-type": "application/json",
@@ -317,6 +350,9 @@ class Auditor:
     def get_project_list(host, key, verify=True):
         """ Return a dictionary with all known projects, or raise exceptions
         upon errors. """
+        assert (host is not None and host != "")
+        assert (key is not None and key != "")
+
         url = host + API_PROJECT
         headers = {
             "content-type": "application/json",
@@ -339,6 +375,11 @@ class Auditor:
         Please see whether the get_project_with_version_id() method
         works for you instead (should be less expensive computationally).
         """
+        assert (host is not None and host != "")
+        assert (key is not None and key != "")
+        assert (project_name is not None and project_name != "")
+        assert (version is not None and version != "")
+
         try:
             response_dict = Auditor.get_project_list(host, key, verify=verify)
             for project in response_dict:
@@ -360,6 +401,11 @@ class Auditor:
         Returns project UUID or "" empty string upon REST API request
         HTTP error states (may raise exceptions on other types of errors).
         """
+        assert (host is not None and host != "")
+        assert (key is not None and key != "")
+        assert (project_name is not None and project_name != "")
+        assert (version is not None and version != "")
+
         project_name = project_name
         version = version
         url = host + API_PROJECT_LOOKUP + '?name={}&version={}'.format(project_name, version)
@@ -379,6 +425,8 @@ class Auditor:
     @staticmethod
     def read_bom_file(filename):
         """ Read original XML or JSON Bom file and re-encode it to DT server's liking. """
+        assert (filename is not None and filename != "")
+
         if Auditor.DEBUG_VERBOSITY > 2:
             print(f"Reading {filename} ...")
         filenameChecked = filename if Path(filename).exists() else str(Path(__file__).parent / filename)
@@ -406,6 +454,14 @@ class Auditor:
 
     @staticmethod
     def read_upload_bom(host, key, project_name, version, filename, auto_create, project_uuid=None, wait=False, verify=True):
+        assert (host is not None and host != "")
+        assert (key is not None and key != "")
+        assert (
+            (project_name is not None and project_name != "" and
+             version is not None and version != "") or
+            (project_uuid is not None and project_uuid != ""))
+        assert (filename is not None and filename != "")
+
         data = Auditor.read_bom_file(filename)
 
         if Auditor.DEBUG_VERBOSITY > 2:
@@ -449,6 +505,11 @@ class Auditor:
                            includeComponents=None, includeProperties=None,
                            includeServices=None, includeTags=None,
                            wait=False, verify=True, safeSleep=3):
+        assert (host is not None and host != "")
+        assert (key is not None and key != "")
+        assert (old_project_version_uuid is not None and old_project_version_uuid != "")
+        assert (new_version is not None and new_version != "")
+
         if Auditor.DEBUG_VERBOSITY > 2:
             print(f"Cloning project+version entity {old_project_version_uuid} to new version {new_version}...")
 
@@ -507,7 +568,7 @@ class Auditor:
             time.sleep(safeSleep)
 
         old_project_obj = None
-        if new_project_uuid is None:
+        if new_project_uuid is None or new_project_uuid == "":
             if Auditor.DEBUG_VERBOSITY > 2:
                 print(f"Querying known projects to identify the new clone ...")
             try:
@@ -520,7 +581,7 @@ class Auditor:
                 else:
                     new_project_uuid = Auditor.get_project_with_version_id(
                         host, key, old_project_obj.get("name"), new_version, verify=verify)
-                    if new_project_uuid is not None:
+                    if new_project_uuid is not None and len(new_project_uuid) > 0:
                         if Auditor.DEBUG_VERBOSITY > 2:
                             print("Query identified the new clone of %s ('%s' version '%s' => '%s') as %s" % (
                                 old_project_version_uuid,
@@ -531,10 +592,10 @@ class Auditor:
                     print(f"Failed to query known projects to identify the new clone: {ex}")
                 pass
 
-        if new_project_uuid is not None and wait:
+        if new_project_uuid is not None and len(new_project_uuid) > 0 and wait:
             Auditor.poll_project_uuid(host, key, new_project_uuid, wait=wait, verify=verify)
 
-        if new_name is not None and (old_project_obj is None or old_project_obj.get("name") != new_name):
+        if new_name is not None and len(new_name) > 0 and (old_project_obj is None or old_project_obj.get("name") != new_name):
             if new_project_uuid is None:
                 raise AuditorException(f"Cannot rename cloned project: new UUID not discovered yet")
             if Auditor.DEBUG_VERBOSITY > 2:
@@ -559,6 +620,12 @@ class Auditor:
                            includeComponents=None, includeProperties=None,
                            includeServices=None, includeTags=None,
                            wait=False, verify=True, safeSleep=3):
+        assert (host is not None and host != "")
+        assert (key is not None and key != "")
+        assert (old_project_name is not None and old_project_name != "")
+        assert (old_project_version is not None and old_project_version != "")
+        assert (new_version is not None and new_version != "")
+
         old_project_version_uuid =\
             Auditor.get_project_with_version_id(host, key, old_project_name, old_project_version, verify)
         assert (old_project_version_uuid is not None and old_project_version_uuid != "")
@@ -573,6 +640,10 @@ class Auditor:
     @staticmethod
     def set_project_active(host, key, project_id, active=True, wait=False, verify=True):
         """ Requires PORTFOLIO_MANAGEMENT permission. """
+        assert (host is not None and host != "")
+        assert (key is not None and key != "")
+        assert (project_id is not None and project_id != "")
+
         payload = {
             "uuid": project_id,
             "active": active
@@ -616,8 +687,13 @@ class Auditor:
 
         TODO: Parse Bom.Metadata.Component if present (XML, JSON) to get fallback name and/or version.
         """
-        assert (old_project_version_uuid is not None or
-                (old_project_name is not None and old_project_version is not None))
+        assert (host is not None and host != "")
+        assert (key is not None and key != "")
+        assert ((old_project_version_uuid is not None and old_project_version_uuid != "") or
+                (old_project_name is not None and old_project_version is not None and
+                 old_project_name != "" and old_project_version != ""
+                 ))
+        assert (filename is not None and filename != "")
 
         # NOTE: name+version are ignored if a UUID is provided
         if old_project_version_uuid is None:
@@ -725,6 +801,9 @@ class Auditor:
 
     @staticmethod
     def get_dependencytrack_version(host, key, verify=True):
+        assert (host is not None and host != "")
+        assert (key is not None and key != "")
+
         if Auditor.DEBUG_VERBOSITY > 2:
             print("getting version of OWASP DependencyTrack")
             print(host, key)

--- a/dtrackauditor/auditor.py
+++ b/dtrackauditor/auditor.py
@@ -338,7 +338,12 @@ class Auditor:
         if r.status_code != 200:
             raise AuditorException(f"Cannot clone {old_project_version_uuid}: {r.status_code} {r.reason}")
 
-        new_project_uuid = json.loads(r.text).get('uuid')
+        new_project_uuid = None
+        if r.text is not None:
+            try:
+                new_project_uuid = json.loads(r.text).get('uuid')
+            except Exception as ignored:
+                pass
         if new_project_uuid and wait:
             Auditor.poll_project_uuid(host, key, new_project_uuid)
 

--- a/dtrackauditor/auditor.py
+++ b/dtrackauditor/auditor.py
@@ -72,7 +72,7 @@ class Auditor:
     @staticmethod
     def poll_response(response):
         if Auditor.DEBUG_VERBOSITY > 3:
-            print(f"poll_response(): {response} => {response.status_code} {response.reason} => {response.text}")
+            print(AuditorRESTAPIException.stringify("poll_response()", response))
         if response.status_code != 200:
             return False
         status = json.loads(response.text).get('processing')
@@ -81,7 +81,7 @@ class Auditor:
     @staticmethod
     def uuid_present(response):
         if Auditor.DEBUG_VERBOSITY > 3:
-            print(f"uuid_present(): {response} => {response.status_code} {response.reason} => {response.text}")
+            print(AuditorRESTAPIException.stringify("uuid_present()", response))
         if response.status_code != 200:
             return False
         uuid = json.loads(response.text).get('uuid')
@@ -91,7 +91,7 @@ class Auditor:
     def entity_absent(response):
         """ Returns a success if specifically the request returned HTTP-404 """
         if Auditor.DEBUG_VERBOSITY > 3:
-            print(f"uuid_present(): {response} => {response.status_code} {response.reason} => {response.text}")
+            print(AuditorRESTAPIException.stringify("entity_absent()", response))
         if response.status_code == 404:
             return True
         return False

--- a/dtrackauditor/auditor.py
+++ b/dtrackauditor/auditor.py
@@ -52,6 +52,28 @@ class Auditor:
         return json.loads(result.text).get('processing')
 
     @staticmethod
+    def poll_project_uuid(host, key, project_uuid, verify=True):
+        """ Polls server until 'project_uuid' info is received.
+        Checks if that info's 'uuid' matches (fails an assert()
+        otherwise) and returns the object decoded from JSON.
+        """
+        print(f"Waiting for project uuid {project_uuid} to be reported by dt server ...")
+        url = host + API_PROJECT + '/{}'.format(project_uuid)
+        headers = {
+            "content-type": "application/json",
+            "X-API-Key": key
+        }
+        result = polling.poll(
+            lambda: requests.get(url, headers=headers, verify=verify),
+            step=5,
+            poll_forever=True,
+            check_success=Auditor.poll_response
+        )
+        resObj = json.loads(result.text)
+        assert (resObj["uuid"] == project_uuid)
+        return resObj
+
+    @staticmethod
     def get_issue_details(component):
         return {
             'cveid': component.get('vulnerability').get('vulnId'),

--- a/dtrackauditor/auditor.py
+++ b/dtrackauditor/auditor.py
@@ -45,14 +45,14 @@ class AuditorRESTAPIException(AuditorException):
         super().__init__(message)
 
     @staticmethod
-    def stringify(message, result):
+    def stringify(message, result, showFullResultText = False):
         s = f"{message}"
         try:
             if result is not None:
                 s += f": HTTP-{result.status_code} {result.reason}"
                 if result.text is None or len(result.text) == 0:
                     s += " <empty response content>"
-                elif len(result.text) < 128:
+                elif len(result.text) < 128 or showFullResultText:
                     s += f" => {result.text}"
                 else:
                     s += f" <response content length is {len(result.text)}>"

--- a/dtrackauditor/auditor.py
+++ b/dtrackauditor/auditor.py
@@ -36,6 +36,11 @@ class Auditor:
         return status == False
 
     @staticmethod
+    def uuid_present(response):
+        uuid = json.loads(response.text).get('uuid')
+        return (uuid is not None and len(uuid) > 0)
+
+    @staticmethod
     def poll_bom_token_being_processed(host, key, bom_token, verify=True):
         print("Waiting for bom to be processed on dt server ...")
         print(f"Processing token uuid is {bom_token}")
@@ -68,7 +73,7 @@ class Auditor:
             lambda: requests.get(url, headers=headers, verify=verify),
             step=5,
             poll_forever=True,
-            check_success=Auditor.poll_response
+            check_success=Auditor.uuid_present
         )
         resObj = json.loads(result.text)
         assert (resObj["uuid"] == project_uuid)

--- a/dtrackauditor/auditor.py
+++ b/dtrackauditor/auditor.py
@@ -316,6 +316,7 @@ class Auditor:
         # even if they seem to duplicate an existing entity. Project UUID
         # of each instance is what matters. Same-ness of names allows it
         # to group separate versions of the project.
+        # UPDATE: Fixed in DT-4.9.0, see https://github.com/DependencyTrack/dependency-track/issues/2958
         payload = {
             "project":              "%s" % old_project_version_uuid,
             "version":              "%s" % new_version,

--- a/dtrackauditor/auditor.py
+++ b/dtrackauditor/auditor.py
@@ -423,7 +423,17 @@ class Auditor:
             print (f"Got response: {r}")
             print (f"Got text: {r.text}")
         if r.status_code != 200:
-            raise AuditorException(f"Cannot clone {old_project_version_uuid}: {r.status_code} {r.reason}")
+            if r.status_code > 500:
+                if Auditor.DEBUG_VERBOSITY > 3:
+                    print (f"Will wait and retry: {r}")
+                time.sleep(5)
+                r = requests.put(host + API_PROJECT_CLONE, data=json.dumps(payload), headers=headers, verify=verify)
+                if Auditor.DEBUG_VERBOSITY > 3:
+                    print (f"Got response: {r}")
+                    print (f"Got text: {r.text}")
+
+            if r.status_code != 200:
+                raise AuditorRESTAPIException(f"Cannot clone {old_project_version_uuid}", r)
 
         new_project_uuid = None
         if r.text is not None:

--- a/dtrackauditor/auditor.py
+++ b/dtrackauditor/auditor.py
@@ -350,7 +350,7 @@ class Auditor:
             "X-API-Key": key
         }
 
-        r = requests.put(
+        r = requests.patch(
             host + API_PROJECT + '/{}'.format(project_id),
             data=json.dumps(payload), headers=headers, verify=verify)
         if r.status_code != 200:

--- a/dtrackauditor/auditor.py
+++ b/dtrackauditor/auditor.py
@@ -561,7 +561,11 @@ class Auditor:
             host + API_PROJECT + '/{}'.format(project_id),
             data=json.dumps(payload), headers=headers, verify=verify)
         if r.status_code != 200:
-            raise AuditorRESTAPIException(f"Cannot modify project {project_id}", r)
+            if r.status_code == 304:
+                if Auditor.DEBUG_VERBOSITY > 2:
+                    print(f"Not changing 'active' status of project to '{active}': it is same as before")
+            else:
+                raise AuditorRESTAPIException(f"Cannot modify project {project_id}", r)
 
         while wait:
             objPrj = Auditor.poll_project_uuid(host, key, project_id, wait=wait, verify=verify)

--- a/dtrackauditor/auditor.py
+++ b/dtrackauditor/auditor.py
@@ -409,6 +409,29 @@ class Auditor:
                 print(f"Sleeping {safeSleep} sec after cloning project {old_project_version_uuid} ...")
             time.sleep(safeSleep)
 
+        if new_project_uuid is None:
+            if Auditor.DEBUG_VERBOSITY > 2:
+                print(f"Querying known projects to identify the new clone ...")
+            try:
+                # First get details (e.g. name) of the old project we cloned from:
+                old_project_obj = Auditor.poll_project_uuid(host, key, old_project_version_uuid, verify=verify)
+                if old_project_obj is None or not isinstance(old_project_obj, dict):
+                    if Auditor.DEBUG_VERBOSITY > 2:
+                        print(f"Failed to query the old project details")
+                else:
+                    new_project_uuid = Auditor.get_project_with_version_id(
+                        host, key, old_project_obj.get("name"), new_version, verify=verify)
+                    if new_project_uuid is not None:
+                        if Auditor.DEBUG_VERBOSITY > 2:
+                            print("Query identified the new clone of %s ('%s' version '%s' => '%s') as %s" % (
+                                old_project_version_uuid,
+                                old_project_obj.get("name"), old_project_obj.get("version"),
+                                new_version, new_project_uuid))
+            except Exception as ex:
+                if Auditor.DEBUG_VERBOSITY > 2:
+                    print(f"Failed to query known projects to identify the new clone: {ex}")
+                pass
+
         if new_project_uuid is not None and wait:
             Auditor.poll_project_uuid(host, key, new_project_uuid)
 

--- a/dtrackauditor/auditor.py
+++ b/dtrackauditor/auditor.py
@@ -46,6 +46,18 @@ class AuditorRESTAPIException(AuditorException):
 
         super().__init__(message)
 
+    def __str__(self):
+        s = f"${self.message}"
+        if self.result is not None:
+            s += ": {result.status_code} {result.reason}"
+            if self.result.text is None or len(self.result.text) == 0:
+                s += " <empty response content>"
+            elif len(self.result.text) < 128:
+                s += f" => {self.result.text}"
+            else:
+                s += f" <response content length is {len(self.result.text)}>"
+        return s
+
 class Auditor:
     DEBUG_VERBOSITY = 3
     """ Library code is peppered with direct prints for the associated

--- a/dtrackauditor/auditor.py
+++ b/dtrackauditor/auditor.py
@@ -22,17 +22,29 @@ class AuditorException(Exception):
     """ Instead of raising an exception that may be caught by code,
     print the message and exit (legacy behavior for the CLI tool) """
 
-    def __init__(self, message = "Dependency-Track Auditor did not pass a test", result = None):
+    def __init__(self, message = "Dependency-Track Auditor did not pass a test"):
         if AuditorException.INSTANT_EXIT:
             print(message)
             sys.exit(1)
 
         self.message = message
 
+        super().__init__(self.message)
+
+class AuditorRESTAPIException(AuditorException):
+    """ Dependency-Track Auditor had a run-time error specifically due to REST API unexpected situation """
+
+    def __init__(self, message = "Dependency-Track Auditor had a REST API unexpected situation", result = None):
+        if AuditorException.INSTANT_EXIT:
+            print(message)
+            if result is not None:
+                print(f"HTTP Result: {result.status_code} {result.reason}")
+            sys.exit(1)
+
         self.result = result
         """ Result of an HTTP query which caused the exception, if any """
 
-        super().__init__(self.message)
+        super().__init__(message)
 
 class Auditor:
     DEBUG_VERBOSITY = 3

--- a/dtrackauditor/auditor.py
+++ b/dtrackauditor/auditor.py
@@ -107,13 +107,20 @@ class Auditor:
             "content-type": "application/json",
             "X-API-Key": key
         }
-        result = polling.poll(
-            lambda: requests.get(url, headers=headers, verify=verify),
-            step=5,
-            poll_forever=(wait if isinstance(wait, bool) else False),
-            timeout=(wait if (isinstance(wait, (int, float)) and not isinstance(wait, bool)) else None), # raises polling.TimeoutException
-            check_success=Auditor.poll_response
-        )
+        if Auditor.DEBUG_VERBOSITY > 2:
+            print(f"poll_forever={(wait if isinstance(wait, bool) else False)}")
+            print(f"timeout={(wait if (isinstance(wait, (int, float)) and not isinstance(wait, bool)) else None)}")
+        # NOTE: poll_forever!=False, ever!
+        if wait:
+            result = polling.poll(
+                lambda: requests.get(url, headers=headers, verify=verify),
+                step=5,
+                poll_forever=(wait if isinstance(wait, bool) else None),
+                timeout=(wait if (isinstance(wait, (int, float)) and not isinstance(wait, bool)) else None), # raises polling.TimeoutException
+                check_success=Auditor.poll_response
+            )
+        else:
+            result = requests.get(url, headers=headers, verify=verify)
         return json.loads(result.text).get('processing')
 
     @staticmethod
@@ -129,13 +136,20 @@ class Auditor:
             "content-type": "application/json",
             "X-API-Key": key
         }
-        result = polling.poll(
-            lambda: requests.get(url, headers=headers, verify=verify),
-            step=5,
-            poll_forever=(wait if isinstance(wait, bool) else False),
-            timeout=(wait if (isinstance(wait, (int, float)) and not isinstance(wait, bool)) else None), # raises polling.TimeoutException
-            check_success=Auditor.uuid_present
-        )
+        if Auditor.DEBUG_VERBOSITY > 2:
+            print(f"poll_forever={(wait if isinstance(wait, bool) else False)}")
+            print(f"timeout={(wait if (isinstance(wait, (int, float)) and not isinstance(wait, bool)) else None)}")
+        # NOTE: poll_forever!=False, ever!
+        if wait:
+            result = polling.poll(
+                lambda: requests.get(url, headers=headers, verify=verify),
+                step=5,
+                poll_forever=(wait if isinstance(wait, bool) else None),
+                timeout=(wait if (isinstance(wait, (int, float)) and not isinstance(wait, bool)) else None), # raises polling.TimeoutException
+                check_success=Auditor.uuid_present
+            )
+        else:
+            result = requests.get(url, headers=headers, verify=verify)
         resObj = json.loads(result.text)
         assert (resObj["uuid"] == project_uuid)
         return resObj

--- a/dtrackauditor/auditor.py
+++ b/dtrackauditor/auditor.py
@@ -37,13 +37,30 @@ class Auditor:
 
     @staticmethod
     def poll_response(response):
+        if Auditor.DEBUG_VERBOSITY > 3:
+            print(f"poll_response(): {response} => {response.status_code} {response.reason} => {response.text}")
+        if response.status_code != 200:
+            return False
         status = json.loads(response.text).get('processing')
-        return status == False
+        return (status == False)
 
     @staticmethod
     def uuid_present(response):
+        if Auditor.DEBUG_VERBOSITY > 3:
+            print(f"uuid_present(): {response} => {response.status_code} {response.reason} => {response.text}")
+        if response.status_code != 200:
+            return False
         uuid = json.loads(response.text).get('uuid')
         return (uuid is not None and len(uuid) > 0)
+
+    @staticmethod
+    def entity_absent(response):
+        """ Returns a success if specifically the request returned HTTP-404 """
+        if Auditor.DEBUG_VERBOSITY > 3:
+            print(f"uuid_present(): {response} => {response.status_code} {response.reason} => {response.text}")
+        if response.status_code == 404:
+            return True
+        return False
 
     @staticmethod
     def poll_bom_token_being_processed(host, key, bom_token, verify=True):

--- a/dtrackauditor/auditor.py
+++ b/dtrackauditor/auditor.py
@@ -184,11 +184,18 @@ class Auditor:
                 timeout=(wait if (isinstance(wait, (int, float)) and not isinstance(wait, bool)) else None), # raises polling.TimeoutException
                 check_success=Auditor.entity_absent
             )
+            if Auditor.DEBUG_VERBOSITY > 3:
+                print(f"OK project uuid {project_uuid} seems deleted")
 
     @staticmethod
     def delete_project(host, key, project_name, version, verify=True, wait=True):
+        if Auditor.DEBUG_VERBOSITY > 3:
+            # Found UUID (if any) will be reported by the called method
+            print(f"Querying for UUID of project to delete ('{project_name}' '{version}')...")
         project_uuid = Auditor.get_project_with_version_id(host, key, project_name, version, verify=verify)
         if project_uuid is None or len(project_uuid) < 1:
+            if Auditor.DEBUG_VERBOSITY > 3:
+                print(f"UUID of project to delete not found")
             return
         Auditor.delete_project_uuid(host, key, project_uuid, verify=verify, wait=wait)
 

--- a/dtrackauditor/auditor.py
+++ b/dtrackauditor/auditor.py
@@ -409,10 +409,12 @@ class Auditor:
                 print(f"Sleeping {safeSleep} sec after cloning project {old_project_version_uuid} ...")
             time.sleep(safeSleep)
 
-        if new_project_uuid and wait:
+        if new_project_uuid is not None and wait:
             Auditor.poll_project_uuid(host, key, new_project_uuid)
 
         if new_name is not None:
+            if new_project_uuid is None:
+                raise AuditorException(f"Cannot rename cloned project: new UUID not discovered yet")
             if Auditor.DEBUG_VERBOSITY > 2:
                 print(f"Renaming cloned project+version entity {new_project_uuid} to new name {new_name} with version {new_version}...")
             r = requests.put(

--- a/dtrackauditor/auditor.py
+++ b/dtrackauditor/auditor.py
@@ -302,11 +302,14 @@ class Auditor:
         if r.status_code != 200:
             raise AuditorException(f"Cannot clone {old_project_version_uuid}: {r.status_code} {r.reason}")
 
+        print (f"Got response: {r}")
+        print (f"Got text: {r.text}")
         new_project_uuid = json.loads(r.text).get('uuid')
         if new_project_uuid and wait:
             Auditor.poll_project_uuid(host, key, new_project_uuid)
 
         if new_name is not None:
+            print(f"Renaming cloned project+version entity {new_project_uuid} to new name {new_name} with version {new_version}...")
             r = requests.put(
                 host + API_PROJECT + '/{}'.format(new_project_uuid),
                 data=json.dumps({"name": "%s" % new_name}),
@@ -336,6 +339,7 @@ class Auditor:
 
     @staticmethod
     def set_project_active(host, key, project_id, active=True, wait=False, verify=True):
+        """ Requires PORTFOLIO_MANAGEMENT permission. """
         payload = {
             "uuid": project_id,
             "active": active


### PR DESCRIPTION
This PR builds upon the impulse of PR #29 and:
* Extends the `AuditorException` family with special-purpose `AuditorRESTAPIException` which can consistently detail the circumstances of a request-related failure
* Adds sanity-checks for many (not all) input parameters of methods
* Splits some methods, so logic can be reused in the library or by external callers
* common `wait` parameter definition extended from just boolean to also accept a number (for finite polling timeout where applicable)
* More debug tracing, now with configurable `Auditor.DEBUG_VERBOSITY` level to hide some more-verbose messages (currently set to show high-level overview of the activity)
* Added methods related to project cloning, renaming, (de-)activation, deletion and lookup, vetted against DT 4.9.0 - overall providing a set of building blocks which allow to upload a new SBOM revision as a new version of a project, inheriting the analysis results applied to the existing version. This includes scenarios for rolling development (same name, different version) and for branching-off releases (new name, new version).

Note that I've tried to retain existing behaviors, but to my liking the original library code did not behave to libraryish :) - it is too noisy, returns empty strings (rather than say `None`) or even directly exits a calling program instead of throwing more actionable exceptions (the `AuditorException` family can be extended for conveying more particular failure scenarios), etc. Some of this got amended by my code, some other things are commented as fishy but not modified too much for the sake of possible existing callers.

I think one thing I changed in the "behavior" was that `get_project_with_version_id()` method would now return `None` explicitly if it found no hits, and an empty string if it had exceptions along the way - could not `get_project_list()` in practical terms. Maybe the `get_project_with_version_id()` should behave similarly, but currently does not - it just returns an empty string if HTTP result was not 200, which in case of a single request is a borderline decision compared to a list :)

Caller code here and elsewhere currently has to clumsily check "if not none and if not empty string then..." but oh well.

Also something "just asking for it" is to forgo static methods (or for the sake of unknown consumers - duplicate with wrappers?) so parameters like server, key, verify can belong to an Auditor object and not have to be passed by caller all the time.