### PR TITLE
Introduce `DTrackClient` class with OOP-style instances

### DIFF
--- a/dtrackauditor/auditor.py
+++ b/dtrackauditor/auditor.py
@@ -148,7 +148,10 @@ class DTrackClient:
                 # Note: This can get reported twice for a chain of events like
                 #   dtc = DTrackClient().initByEnvvars().sanityCheck()
                 # (once from init() defaults and once from a missing envvar value)
-                print("Auditor.normalizeSslVerify(): defaulting ssl_verify=%s" % str(self.ssl_verify))
+                print("Auditor.normalizeSslVerify(): defaulting ssl_verify=%s%s" % (
+                    str(self.ssl_verify),
+                    ": DependencyTrack server is HTTPS but no path to file with cert chain was provided (may be required if not using a well-known CA)" if self.ssl_verify else ""
+                ))
 
         if isinstance(self.ssl_verify, str):
             self.ssl_verify = self.ssl_verify.strip()
@@ -239,7 +242,7 @@ class DTrackClient:
                 if len(self.ssl_verify) == 0:
                     raise AuditorException('DependencyTrack SSL verification is not set properly: seems set but is empty. Set Env $DTRACK_SERVER_CERTCHAIN to path name or boolean value')
                 if not Path(self.ssl_verify).exists():
-                    raise AuditorException("DependencyTrack SSL verification is not set properly: seems set but path '%s' does not exist. Set Env $DTRACK_SERVER_CERTCHAIN to path name or boolean value" % str(self.ssl_verify))
+                    raise AuditorException("DependencyTrack SSL verification is not set properly: seems set but specified path to file with cert chain '%s' does not exist. Set Env $DTRACK_SERVER_CERTCHAIN to path name or boolean value" % str(self.ssl_verify))
             else:
                 if not isinstance(self.ssl_verify, bool):
                     raise AuditorException('DependencyTrack SSL verification is not set properly. Set Env $DTRACK_SERVER_CERTCHAIN to path name or boolean value')

--- a/dtrackauditor/auditor.py
+++ b/dtrackauditor/auditor.py
@@ -144,7 +144,10 @@ class DTrackClient:
         if self.ssl_verify is None:
             self.ssl_verify = self.isBaseUrlHTTPS()
             if Auditor.DEBUG_VERBOSITY > 0:
-                print("Auditor.init(): defaulting ssl_verify=%s" % str(self.ssl_verify))
+                # Note: This can get reported twice for a chain of events like
+                #   dtc = DTrackClient().initByEnvvars().sanityCheck()
+                # (once from init() defaults and once from a missing envvar value)
+                print("Auditor.normalizeSslVerify(): defaulting ssl_verify=%s" % str(self.ssl_verify))
 
         if isinstance(self.ssl_verify, str):
             self.ssl_verify = self.ssl_verify.strip()

--- a/dtrackauditor/auditor.py
+++ b/dtrackauditor/auditor.py
@@ -120,7 +120,7 @@ class DTrackClient:
             else:
                 if ['true', 'yes', 'on', '1'].contains(str(self.ssl_verify).lower()):
                     self.ssl_verify = True
-                if ['false', 'no', 'off', '0'].contains(str(self.ssl_verify).lower()):
+                if ['false', 'none', 'no', 'off', '0'].contains(str(self.ssl_verify).lower()):
                     self.ssl_verify = False
 
         if self.ssl_verify is None:

--- a/dtrackauditor/auditor.py
+++ b/dtrackauditor/auditor.py
@@ -187,20 +187,32 @@ class DTrackClient:
         self.normalizeSslVerify()
         return self
 
-    def initByEnvvars(self, base_url: str|None = 'DTRACK_SERVER', api_key: str|None = 'DTRACK_API_KEY', ssl_verify: str|None = 'DTRACK_SERVER_CERTCHAIN'): # -> DTrackClient:
-        if base_url is not None:
-            self.base_url = os.environ.get(base_url)
+    def initByEnvvars(
+            self,
+            base_url_varname: str|None = 'DTRACK_SERVER',
+            base_url_default: str|None = None,
+            api_key_varname: str|None = 'DTRACK_API_KEY',
+            api_key_default: str|None = None,
+            ssl_verify_varname: str|None = 'DTRACK_SERVER_CERTCHAIN',
+            ssl_verify_default: str|None = None
+    ): # -> DTrackClient:
+        """ (Re-)initialize settings from environment variables whose names
+        are specified by arguments, with optional fallback default values.
+        You can specify something_varname=None to avoid (re-)setting that value.
+        """
+        if base_url_varname is not None:
+            self.base_url = os.environ.get(base_url_varname, base_url_default)
             if self.base_url is None or len(self.base_url) == 0:
                 if Auditor.DEBUG_VERBOSITY > 0:
                     print("Auditor.initByEnvvars(): WARNING: no URL found via envvar '%s'" % base_url)
 
-        if api_key is not None:
-            self.api_key = os.environ.get(api_key)
+        if api_key_varname is not None:
+            self.api_key = os.environ.get(api_key_varname, api_key_default)
             if (self.api_key is None or len(self.api_key) == 0) and Auditor.DEBUG_VERBOSITY > 0:
                 print("Auditor.initByEnvvars(): WARNING: no API Key found via envvar '%s'" % api_key)
 
-        if ssl_verify is not None:
-            self.ssl_verify = os.environ.get(ssl_verify)
+        if ssl_verify_varname is not None:
+            self.ssl_verify = os.environ.get(ssl_verify_varname, ssl_verify_default)
             if self.ssl_verify is None or len(self.ssl_verify) == 0:
                 if Auditor.DEBUG_VERBOSITY > 0 and str(self.base_url).lower().startswith('https://'):
                     print("Auditor.initByEnvvars(): WARNING: no explicit verification toggle or cert chain found via envvar '%s'" % ssl_verify)

--- a/dtrackauditor/auditor.py
+++ b/dtrackauditor/auditor.py
@@ -110,6 +110,36 @@ class DTrackClient:
             self.api_key = self.api_key.strip()
         return self.api_key
 
+    @staticmethod
+    def tryAsBool(
+            val,
+            meaningOfNone: bool|None = False,
+            meaningOfEmptyString: bool|None = True
+    ):
+        """ Converts certain values of "val" (case-insensitive string or
+        integer) into a bool. Special consideration for None and "None"
+        (string), and for an empty string (after stripping whitespace).
+        If there is no match, keeps and returns "val" as is.
+        """
+        if val is None:
+            if meaningOfNone is not None:
+                val = meaningOfNone
+        else:
+            if isinstance(val, str) or isinstance(val, int):
+                tmp = str(val).strip().lower()
+                if len(tmp) > 0:
+                    if tmp in ['true', 'yes', 'on', '1']:
+                        val = True
+                    if tmp in ['false', 'no', 'off', '0']:
+                        val = False
+                    if meaningOfNone is not None and tmp == "none":
+                        val = meaningOfNone
+                else:
+                    if meaningOfEmptyString is not None:
+                        val = meaningOfEmptyString
+
+        return val
+
     def normalizeSslVerify(self):
         if self.ssl_verify is None:
             self.ssl_verify = self.isBaseUrlHTTPS()
@@ -119,11 +149,7 @@ class DTrackClient:
         if isinstance(self.ssl_verify, str):
             self.ssl_verify = self.ssl_verify.strip()
 
-            if len(self.ssl_verify) > 0:
-                if ['true', 'yes', 'on', '1'].contains(str(self.ssl_verify).lower()):
-                    self.ssl_verify = True
-                if ['false', 'none', 'no', 'off', '0'].contains(str(self.ssl_verify).lower()):
-                    self.ssl_verify = False
+        self.ssl_verify = DTrackClient.tryAsBool(self.ssl_verify)
 
         return self.ssl_verify
 

--- a/dtrackauditor/auditor.py
+++ b/dtrackauditor/auditor.py
@@ -143,14 +143,18 @@ class DTrackClient:
 
     def normalizeSslVerify(self):
         if self.ssl_verify is None:
+            if self.base_url is None:
+                return None
+
             self.ssl_verify = self.isBaseUrlHTTPS()
             if Auditor.DEBUG_VERBOSITY > 0:
                 # Note: This can get reported twice for a chain of events like
                 #   dtc = DTrackClient().initByEnvvars().sanityCheck()
                 # (once from init() defaults and once from a missing envvar value)
-                print("Auditor.normalizeSslVerify(): defaulting ssl_verify=%s%s" % (
+                print("Auditor.normalizeSslVerify(): defaulting ssl_verify=%s for base URL %s%s" % (
                     str(self.ssl_verify),
-                    ": DependencyTrack server is HTTPS but no path to file with cert chain was provided (may be required if not using a well-known CA)" if self.ssl_verify else ""
+                    str(self.base_url),
+                    " : DependencyTrack server is HTTPS but no path to file with cert chain was provided (may be required if not using a well-known CA)" if self.ssl_verify else ""
                 ))
 
         if isinstance(self.ssl_verify, str):


### PR DESCRIPTION
This library was originally designed as an internal detail of a CLI tool. Each call to the library methods has to pass the url, API key and optional SSL validation settings, which is cumbersome.

This PR is about wrapping the existing logic with OOP-style class instances, whose properties would hold and pass around these credentials (as well as optionally sanity-check them and slurp from envvars), which allows for cleaner consumer codebase when this project is used as an actual library.

Also stabilize the use of method arg names (e.g. project ID vs UUID).

Quick sample usable in interactive python (note a new "import" needed to use this class directly):
````
try:
    from dtrackauditor.auditor import Auditor
    from dtrackauditor.auditor import AuditorException
    from dtrackauditor.auditor import DTrackClient
except ModuleNotFoundError:
    # Same dir (running from Git checkout)?..
    from auditor import Auditor
    from auditor import AuditorException
    from auditor import DTrackClient

dtc = DTrackClient().initByEnvvars().sanityCheck()
print(dtc)

print (dtc.get_dependencytrack_version())
````