### PR TITLE
feat: Addition of parent project functionality (reapply PR #21)

### DIFF
--- a/dtrackauditor/auditor.py
+++ b/dtrackauditor/auditor.py
@@ -431,7 +431,7 @@ class Auditor:
             print(f"Reading {filename} ...")
         filenameChecked = filename if Path(filename).exists() else str(Path(__file__).parent / filename)
         if filenameChecked != filename and Auditor.DEBUG_VERBOSITY > 2:
-            print(f"Actually, found it as {filenameChecked} ...")
+            print(f"Actually, resolved it as {filenameChecked} ...")
 
         if not Path(filenameChecked).exists():
             raise AuditorException(f"{filenameChecked} not found !")

--- a/dtrackauditor/auditor.py
+++ b/dtrackauditor/auditor.py
@@ -453,7 +453,13 @@ class Auditor:
         #return None
 
     @staticmethod
-    def read_upload_bom(host, key, project_name, version, filename, auto_create, project_uuid=None, wait=False, verify=True):
+    def read_upload_bom(
+        host, key,
+        project_name, version, filename, auto_create,
+        project_uuid=None,
+        parent_project=None, parent_version=None, parent_uuid=None,
+        wait=False, verify=True
+    ):
         assert (host is not None and host != "")
         assert (key is not None and key != "")
         assert (
@@ -483,6 +489,16 @@ class Auditor:
 
         if version is not None:
             payload["projectVersion"] = version
+
+        # These where added in version 4.8 of DT
+        if parent_project:
+            payload["parentName"] =  parent_project
+
+        if parent_version:
+            payload["parentVersion"] = parent_version
+
+        if parent_uuid:
+            payload["parentUUID"] = parent_uuid
 
         headers = {
             "content-type": "application/json",

--- a/dtrackauditor/auditor.py
+++ b/dtrackauditor/auditor.py
@@ -515,12 +515,14 @@ class Auditor:
         return bom_token
 
     @staticmethod
-    def clone_project_by_uuid(host, key, old_project_version_uuid,
-                           new_version, new_name=None, includeALL=True,
-                           includeACL=None, includeAuditHistory=None,
-                           includeComponents=None, includeProperties=None,
-                           includeServices=None, includeTags=None,
-                           wait=False, verify=True, safeSleep=3):
+    def clone_project_by_uuid(
+            host, key, old_project_version_uuid,
+            new_version, new_name=None, includeALL=True,
+            includeACL=None, includeAuditHistory=None,
+            includeComponents=None, includeProperties=None,
+            includeServices=None, includeTags=None,
+            wait=False, verify=True, safeSleep=3
+    ):
         assert (host is not None and host != "")
         assert (key is not None and key != "")
         assert (old_project_version_uuid is not None and old_project_version_uuid != "")
@@ -630,12 +632,14 @@ class Auditor:
         return new_project_uuid
 
     @staticmethod
-    def clone_project_by_name_version(host, key, old_project_name, old_project_version,
-                           new_version, new_name=None, includeALL=True,
-                           includeACL=None, includeAuditHistory=None,
-                           includeComponents=None, includeProperties=None,
-                           includeServices=None, includeTags=None,
-                           wait=False, verify=True, safeSleep=3):
+    def clone_project_by_name_version(
+            host, key, old_project_name, old_project_version,
+            new_version, new_name=None, includeALL=True,
+            includeACL=None, includeAuditHistory=None,
+            includeComponents=None, includeProperties=None,
+            includeServices=None, includeTags=None,
+            wait=False, verify=True, safeSleep=3
+    ):
         assert (host is not None and host != "")
         assert (key is not None and key != "")
         assert (old_project_name is not None and old_project_name != "")

--- a/dtrackauditor/auditor.py
+++ b/dtrackauditor/auditor.py
@@ -693,11 +693,13 @@ class Auditor:
             old_project_name=None, old_project_version=None,
             activate_old=None, activate_new=None,
             deleteExistingClone=False,
+            parent_project=None, parent_version=None, parent_uuid=None,
             includeALL=True,
             includeACL=None, includeAuditHistory=None,
             includeComponents=None, includeProperties=None,
             includeServices=None, includeTags=None,
-            wait=True, verify=True, safeSleep=3):
+            wait=True, verify=True, safeSleep=3
+    ):
         """
         Clones an existing project and uploads a new SBOM document into it, in one swift operation.
 
@@ -799,6 +801,7 @@ class Auditor:
         bom_token = Auditor.read_upload_bom(
             host, key, project_name=None, version=None,
             filename=filename, auto_create=False, project_uuid=new_project_uuid,
+            parent_project=parent_project, parent_version=parent_version, parent_uuid=parent_uuid,
             wait=wait, verify=verify)
 
         assert (bom_token is not None and bom_token != "")

--- a/dtrackauditor/dtrackauditor.py
+++ b/dtrackauditor/dtrackauditor.py
@@ -130,7 +130,7 @@ def main():
     print('Provided project name and version: ', project_name, version)
     if args.auto:
         print('Auto mode ON')
-        Auditor.read_upload_bom(dt_server, dt_api_key, project_name, version, filename, True, wait=args.wait, verify=args.certchain)
+        Auditor.read_upload_bom(dt_server, dt_api_key, project_name, version, filename, True, None, parent_project, parent_version, parent_uuid, wait=args.wait, verify=args.certchain)
         project_uuid = Auditor.get_project_with_version_id(dt_server, dt_api_key, project_name, version, verify=args.certchain)
         print(f'Project UUID: {project_uuid}')
 
@@ -138,7 +138,7 @@ def main():
             Auditor.check_policy_violations(dt_server, dt_api_key, project_uuid, verify=args.certchain)
             Auditor.check_vulnerabilities(dt_server, dt_api_key, project_uuid, args.rules, show_details, verify=args.certchain)
     else:
-        Auditor.read_upload_bom(dt_server, dt_api_key, project_name, version, filename, parent_project, parent_version, parent_uuid, False, wait=args.wait, verify=args.certchain)
+        Auditor.read_upload_bom(dt_server, dt_api_key, project_name, version, filename, False, None, parent_project, parent_version, parent_uuid, wait=args.wait, verify=args.certchain)
 
 if __name__ == '__main__':
    main()


### PR DESCRIPTION
* Replay changes from PR #21 by @andy778 after the big changes of PR #30
* Modify `read_upload_bom()` new arguments `parent_project`, `parent_version`, `parent_uuid` to be optional (and so come later in method argument order); adapt consumers in `dtrackauditor.py` accordingly

Closes: #20