### PR TITLE
Fix in #50 was overly zealous

### DIFF
--- a/dtrackauditor/auditor.py
+++ b/dtrackauditor/auditor.py
@@ -667,7 +667,9 @@ class Auditor:
         if show_details == 'TRUE' or show_details == 'ALL':
             for items in vuln_details:
                 print(items)
-# the condition for checking rules  i.e. -r critical:1:false,high:2:false,medium:10:false,low:10:false
+
+        # the condition for checking rules, i.e.
+        #   -r critical:1:false,high:2:false,medium:10:false,low:10:false
         for rule in rules:
             severity, count, fail = rule.split(':')
             severity = severity.strip()

--- a/dtrackauditor/auditor.py
+++ b/dtrackauditor/auditor.py
@@ -211,18 +211,18 @@ class DTrackClient:
             self.base_url = os.environ.get(base_url_varname, base_url_default)
             if self.base_url is None or len(self.base_url) == 0:
                 if Auditor.DEBUG_VERBOSITY > 0:
-                    print("Auditor.initByEnvvars(): WARNING: no URL found via envvar '%s'" % self.base_url)
+                    print("Auditor.initByEnvvars(): WARNING: no URL found via envvar '%s'" % base_url_varname)
 
         if api_key_varname is not None:
             self.api_key = os.environ.get(api_key_varname, api_key_default)
             if (self.api_key is None or len(self.api_key) == 0) and Auditor.DEBUG_VERBOSITY > 0:
-                print("Auditor.initByEnvvars(): WARNING: no API Key found via envvar '%s'" % self.api_key)
+                print("Auditor.initByEnvvars(): WARNING: no API Key found via envvar '%s'" % api_key_varname)
 
         if ssl_verify_varname is not None:
             self.ssl_verify = os.environ.get(ssl_verify_varname, ssl_verify_default)
             if self.ssl_verify is None or len(self.ssl_verify) == 0:
                 if Auditor.DEBUG_VERBOSITY > 0 and str(self.base_url).lower().startswith('https://'):
-                    print("Auditor.initByEnvvars(): WARNING: no explicit verification toggle or cert chain found via envvar '%s'" % self.ssl_verify)
+                    print("Auditor.initByEnvvars(): WARNING: no explicit verification toggle or cert chain found via envvar '%s'" % ssl_verify_varname)
 
         self.normalize()
 


### PR DESCRIPTION
Amending some changes from PR #50 which broke the code a bit: we should not be reporting `self.base_url` etc. in `Auditor.initByEnvvars()` when they are `None` or empty: the point of the message was to report that the *envvar* involved did not give us needed info, so we report its name in that message.