### PR TITLE
dtrackauditor/auditor.py: fix `clone_project_by_uuid()` and…

### DIFF
--- a/dtrackauditor/auditor.py
+++ b/dtrackauditor/auditor.py
@@ -1202,6 +1202,10 @@ class Auditor:
                 pass
 
         if new_project_uuid is not None and len(new_project_uuid) > 0 and wait:
+            # Before DT 4.11, project-cloning is not atomic and
+            # the new instance's component count grows over time
+            # until it hits the original numbers. Only after that
+            # should SBOM upload happen, for example.
             new_project_version_info = Auditor.poll_project_uuid(host, key, new_project_uuid, wait=wait, verify=verify)
             try:
                 old_count = old_project_version_info["metrics"]["components"]

--- a/dtrackauditor/auditor.py
+++ b/dtrackauditor/auditor.py
@@ -1210,11 +1210,19 @@ class Auditor:
             try:
                 old_count = old_project_version_info["metrics"]["components"]
                 if old_count > 0:
-                    new_count = new_project_version_info["metrics"]["components"]
-                    while new_count < old_count:
-                        sleep(5)
-                        new_project_version_info = Auditor.poll_project_uuid(host, key, new_project_uuid, wait=wait, verify=verify)
+                    try:
                         new_count = new_project_version_info["metrics"]["components"]
+                    except Exception as exDict:
+                        new_count = -1
+
+                    while new_count < old_count:
+                        time.sleep(5)
+                        Auditor.request_project_metrics_refresh(host, key, new_project_uuid, wait=wait, verify=verify)
+                        new_project_version_info = Auditor.poll_project_uuid(host, key, new_project_uuid, wait=wait, verify=verify)
+                        try:
+                            new_count = new_project_version_info["metrics"]["components"]
+                        except Exception as exDict:
+                            new_count = -1
             except Exception as ex:
                 # Could not pass the dict?
                 if Auditor.DEBUG_VERBOSITY > 2:

--- a/dtrackauditor/auditor.py
+++ b/dtrackauditor/auditor.py
@@ -1227,6 +1227,8 @@ class Auditor:
                 # Could not pass the dict?
                 if Auditor.DEBUG_VERBOSITY > 2:
                     print(f"Could not poll and wait for new project to have same component count as the old instance: %s" % (str(ex)))
+            if Auditor.DEBUG_VERBOSITY > 2:
+                print(f"The cloned project+version entity {new_project_uuid} has at least as many components ({new_count}) as the original entity {old_project_version_uuid} ({old_count})")
 
         if new_name is not None and len(new_name) > 0 and (old_project_obj is None or old_project_obj.get("name") != new_name):
             if new_project_uuid is None:

--- a/dtrackauditor/auditor.py
+++ b/dtrackauditor/auditor.py
@@ -426,7 +426,7 @@ class DTrackClient:
             project_name, version, filename, auto_create,
             project_id=None,
             parent_project=None, parent_version=None, parent_id=None,
-            wait=False
+            wait=True
     ):
         retval = Auditor.read_upload_bom(
             host=self.base_url, key=self.api_key,
@@ -1003,7 +1003,7 @@ class Auditor:
         project_name, version, filename, auto_create,
         project_uuid=None,
         parent_project=None, parent_version=None, parent_uuid=None,
-        wait=False, verify=True
+        wait=True, verify=True
     ):
         assert (host is not None and host != "")
         assert (key is not None and key != "")


### PR DESCRIPTION
… `clone_project_by_name_version()` implementations to wait=True by default, and when waiting - to check that component count in the new instance becomes same as (or potentionally greater than) in the original