### PR TITLE
Update GitHub Actions checkout and upload-artifact to v4

### DIFF
--- a/.github/workflows/cyclonedx.yml
+++ b/.github/workflows/cyclonedx.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         
       - name: Generate Python SBOM
         uses: CycloneDX/gh-python-generate-sbom@v2
@@ -22,7 +22,7 @@ jobs:
           format: json
           
       - name: Upload SBOM artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: sbom
           path: ./bom.json

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python
       uses: actions/setup-python@v3
       with:

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -32,7 +32,7 @@ jobs:
 
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
 
@@ -59,7 +59,7 @@ jobs:
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
       - name: "Upload artifact"
-        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # v3.1.0
+        uses: actions/upload-artifact@v4
         with:
           name: SARIF file
           path: results.sarif


### PR DESCRIPTION
https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/

In `scorecard.yml` I tentatively proposed to use the newer releases rather than older snapshots by commit ID, but ossf/sarif actions remain referenced by ID for now, not sure what to do with those at the moment. I do not know why commit hashes were used in the first place (assuming at that time available releases were not functional in the way this project wanted?) but note that currently in `master` branch both scorecard and cyclonedx checks fail...

CC @thinksabin