### PR TITLE
Fix `read_upload_bom()` for empty-string `old_project_version_uuid` (meaning it was not found)

### DIFF
--- a/dtrackauditor/auditor.py
+++ b/dtrackauditor/auditor.py
@@ -1870,17 +1870,16 @@ class Auditor:
         }
 
         old_project_version_uuid = project_uuid
-        if old_project_version_uuid == "":
-            # Rationale commented below
-            old_project_version_uuid = None
         old_project_version_info = None
         old_lastBOMImport = None
         try:
-            if old_project_version_uuid is None and project_name is not None and version is not None:
+            if ((old_project_version_uuid is None or len(old_project_version_uuid) < 1)
+                    and project_name is not None and version is not None):
                 old_project_version_uuid = Auditor.get_project_with_version_id(host, key, project_name, version, verify)
-            if old_project_version_uuid == "":
+            if len(old_project_version_uuid) < 1:
                 # HTTP error reported when retrieving, but
-                # connection etc. did not fail so not None
+                # connection etc. did not fail so not None.
+                # This re-assignment simplifies checks below.
                 old_project_version_uuid = None
             if old_project_version_uuid is not None:
                 old_project_version_info = Auditor.poll_project_uuid(host, key, old_project_version_uuid, True, verify)
@@ -1907,6 +1906,9 @@ class Auditor:
                 if new_project_version_uuid is None and project_name is not None and version is not None:
                     # FIXME: ` and auto_create is True` ?
                     new_project_version_uuid = Auditor.get_project_with_version_id(host, key, project_name, version, verify)
+                if len(new_project_version_uuid) < 1:
+                    # See comments in the block above.
+                    new_project_version_uuid = None
                 if new_project_version_uuid is not None:
                     new_project_version_info = Auditor.poll_project_uuid(host, key, new_project_version_uuid, True, verify)
                 if new_project_version_info is not None:

--- a/dtrackauditor/auditor.py
+++ b/dtrackauditor/auditor.py
@@ -1870,18 +1870,25 @@ class Auditor:
         }
 
         old_project_version_uuid = project_uuid
+        if old_project_version_uuid == "":
+            # Rationale commented below
+            old_project_version_uuid = None
         old_project_version_info = None
         old_lastBOMImport = None
         try:
             if old_project_version_uuid is None and project_name is not None and version is not None:
                 old_project_version_uuid = Auditor.get_project_with_version_id(host, key, project_name, version, verify)
+            if old_project_version_uuid == "":
+                # HTTP error reported when retrieving, but
+                # connection etc. did not fail so not None
+                old_project_version_uuid = None
             if old_project_version_uuid is not None:
                 old_project_version_info = Auditor.poll_project_uuid(host, key, old_project_version_uuid, True, verify)
             if old_project_version_info is not None:
                 old_lastBOMImport = int(old_project_version_info["lastBomImport"])
         except Exception as ex:
             if Auditor.DEBUG_VERBOSITY > 0:
-                print(f"Cannot get project '{old_project_version_uuid}' (for '{project_name}' '{version}') info details before SBOM upload: {str(ex)}")
+                print(f"Cannot get project '{str(old_project_version_uuid)}' (for '{project_name}' '{version}') info details before SBOM upload: {str(ex)}")
             pass
 
         r = requests.put(host + API_BOM_UPLOAD, data=json.dumps(payload), headers=headers, verify=verify)

--- a/dtrackauditor/auditor.py
+++ b/dtrackauditor/auditor.py
@@ -2111,7 +2111,7 @@ class Auditor:
 
         old_project_version_uuid =\
             Auditor.get_project_with_version_id(host, key, old_project_name, old_project_version, verify)
-        assert (old_project_version_uuid is not None and old_project_version_uuid != "")
+        assert (old_project_version_uuid is not None and len(old_project_version_uuid) > 0)
         return Auditor.clone_project_by_uuid(
             host, key, old_project_version_uuid,
             new_version, new_name, includeALL,
@@ -2188,7 +2188,7 @@ class Auditor:
             old_project_version_uuid = \
                 Auditor.get_project_with_version_id(host, key, old_project_name, old_project_version, verify)
 
-        assert (old_project_version_uuid is not None and old_project_version_uuid != "")
+        assert (old_project_version_uuid is not None and len(old_project_version_uuid) > 0)
         old_project_obj = Auditor.poll_project_uuid(
             host, key, old_project_version_uuid, wait=wait, verify=verify)
 

--- a/dtrackauditor/auditor.py
+++ b/dtrackauditor/auditor.py
@@ -1704,12 +1704,18 @@ class Auditor:
         Look up a particular project instance by name and version,
         querying for a list of all projects and filtering that.
 
-        Returns project UUID or "" upon REST API request HTTP
-        error states (may raise exceptions on other types of errors)
-        or None if nothing was found (without errors).
-
-        Please see whether the get_project_with_version_id() method
+        NOTE: Please see whether the get_project_with_version_id() method
         works for you instead (should be less expensive computationally).
+
+        Returns:
+
+        * a string with project UUID reported by the REST API server
+          if the HTTP request was successful and contained an UUID
+          for this project name and version,
+        * None if the HTTP request was successful but did not contain
+          the UUID for this project name and version, or
+        * an "" empty string upon REST API request HTTP error states;
+        * methods used may raise exceptions on other types of errors.
         """
 
         assert (host is not None and host != "")
@@ -1736,8 +1742,15 @@ class Auditor:
         Look up a particular project instance by name and version,
         using a dedicated REST API call for that purpose.
 
-        Returns project UUID or "" empty string upon REST API request
-        HTTP error states (may raise exceptions on other types of errors).
+        Returns:
+
+        * a string with project UUID reported by the REST API server
+          if the HTTP request was successful and contained an UUID
+          for this project name and version,
+        * None if the HTTP request was successful but did not contain
+          the UUID for this project name and version, or
+        * an "" empty string upon REST API request HTTP error states;
+        * methods used may raise exceptions on other types of errors.
         """
 
         assert (host is not None and host != "")
@@ -1759,6 +1772,7 @@ class Auditor:
             # TODO? raise AuditorRESTAPIException("Cannot get project id", res)
             return ""
         response_dict = json.loads(res.text)
+        # May be None if key was not found for some reason (unsupported DT version?)
         return response_dict.get('uuid')
 
     @staticmethod
@@ -2269,7 +2283,14 @@ class Auditor:
 
     @staticmethod
     def get_dependencytrack_version(host, key, verify=True):
-        """ Get version information of the Dependency-Track server instance itself. """
+        """
+        Get version information of the Dependency-Track server instance itself.
+
+        Returns a dict with information reported by the REST API server
+        if the HTTP request was successful, or an "" empty string upon
+        REST API request HTTP error states (may raise exceptions on other
+        types of errors).
+        """
 
         assert (host is not None and host != "")
         assert (key is not None and key != "")


### PR DESCRIPTION
Logical problem detailed at https://github.com/thinksabin/DTrackAuditor/issues/79#issuecomment-2416941912

Closes: #79

Local testing of uploads into currently missing project name/version:

* Failed tolerance thresholds for vuln/policy alerts (another `AuditorException.INSTANT_EXIT` - but an expected one for the situation):
````
:; $PYTHON3 ./dtrackauditor/dtrackauditor.py -u "${DTRACK_SERVER}"  -k "${DTRACK_API_KEY}"  -p New-Test-Project -f bom.json -a --wait -r critical:1:true,high:2:true,medium:10:true,low:10:false

Provided project name and version:  New-Test-Project 1.0.0
Auto mode ON
Reading bom.json ...
Uploading bom.json ...
Cannot get project 'New-Test-Project' '1.0.0' id: 404 Not Found
Waiting for bom to be processed on dt server ...
Waiting for project uuid 87d0551e-f8ca-4213-94c9-9974c1886260 to be reported by dt server ...
Uploaded BOM 'bom.json' into project '87d0551e-f8ca-4213-94c9-9974c1886260' (for 'New-Test-Project' '1.0.0'), it reports lastBomImport: 1729086325061 (old one was None) and token '9a889b5d-d374-4370-aaba-6aba1b50f963'
Project UUID: 87d0551e-f8ca-4213-94c9-9974c1886260
No policy violations found.
severity_scores,   {'CRITICAL': 1, 'HIGH': 12, 'MEDIUM': 6, 'LOW': 0, 'UNASSIGNED': 25}
AuditorException.INSTANT_EXIT: Threshold for CRITICAL severity issues exceeded. Failing as per instructed rules (-r)

:; echo $?
1
````

* Passing the alerts:
````
:; $PYTHON3 ./dtrackauditor/dtrackauditor.py -u "${DTRACK_SERVER}"  -k "${DTRACK_API_KEY}"  -p New-Test-Project-HighThreshold -f bom.json -a --wait -r critical:100:true,high:200:true,medium:100:true,low:100:false

Provided project name and version:  New-Test-Project-HighThreshold 1.0.0
Auto mode ON
Reading bom.json ...
Uploading bom.json ...
Cannot get project 'New-Test-Project-HighThreshold' '1.0.0' id: 404 Not Found
Waiting for bom to be processed on dt server ...
Waiting for project uuid c7cc4694-8d6d-42ef-9efa-31307b76479c to be reported by dt server ...
Uploaded BOM 'bom.json' into project 'c7cc4694-8d6d-42ef-9efa-31307b76479c' (for 'New-Test-Project-HighThreshold' '1.0.0'), it reports lastBomImport: 1729086374144 (old one was None) and token '5a351238-909c-4b00-bb00-e86653d38323'
Project UUID: c7cc4694-8d6d-42ef-9efa-31307b76479c
No policy violations found.
severity_scores,   {'CRITICAL': 1, 'HIGH': 12, 'MEDIUM': 6, 'LOW': 0, 'UNASSIGNED': 25}
Vulnerability audit resulted in no violations.

:; echo $?
0
````