### PR TITLE
Clone project - support new DT args

### DIFF
--- a/dtrackauditor/auditor.py
+++ b/dtrackauditor/auditor.py
@@ -711,6 +711,15 @@ class Auditor:
     around. It could not be squashed into the same class (at least not
     while using same method names). """
 
+    cached_dependencytrack_versions = {}
+    """
+    Dict to store each tried host's last returned details from the
+    get_dependencytrack_version() method. Maps string to further dict.
+
+    May be used to fence calls added in recent DT releases,
+    to avoid setting unsupported parameters to older REST API.
+    """
+
     @staticmethod
     def get_paginated(url, headers, verify=True):
         """ Get a response from paginated API calls.
@@ -2293,6 +2302,8 @@ class Auditor:
         response_dict = json.loads(res.text)
         if Auditor.DEBUG_VERBOSITY > 2:
             print(response_dict)
+
+        Auditor.cached_dependencytrack_versions[host] = response_dict
         return response_dict
 
     @staticmethod


### PR DESCRIPTION
Add optional support for DT project-cloning REST API features that may require specific (or newer) recent versions of the server.

* Note: not sure about "requiring" yet - so not throwing preliminary exceptions if a parameter was not `None` and the DT version was too old or unknown. At worst, the REST API call itself would return "not HTTP-200".
* Part of the solution was to remember the last-reported version info from each (likely single) `host` when we `get_dependencytrack_version()`
* Currently the version-parsing (from JSON into numbers) is done inside the one method that needs it. I can imagine it generalized to some more general parser if such fencing proves needed elsewhere in the future, and/or using the SemVer module or similar - to not reinvent a particularly complex wheel here :)
* Discussing with DT team that new similar tweaks could appear in future server releases - e.g. https://github.com/DependencyTrack/dependency-track/issues/4279 - here we would have an example how to tame them :)