### PR TITLE
Clone project inverted upload: support clone+upload mode to change the original (not cloned) project instance

### DIFF
--- a/dtrackauditor/auditor.py
+++ b/dtrackauditor/auditor.py
@@ -711,6 +711,15 @@ class Auditor:
     around. It could not be squashed into the same class (at least not
     while using same method names). """
 
+    cached_dependencytrack_versions = {}
+    """
+    Dict to store each tried host's last returned details from the
+    get_dependencytrack_version() method. Maps string to further dict.
+
+    May be used to fence calls added in recent DT releases,
+    to avoid setting unsupported parameters to older REST API.
+    """
+
     @staticmethod
     def get_paginated(url, headers, verify=True):
         """ Get a response from paginated API calls.
@@ -2293,6 +2302,8 @@ class Auditor:
         response_dict = json.loads(res.text)
         if Auditor.DEBUG_VERBOSITY > 2:
             print(response_dict)
+
+        Auditor.cached_dependencytrack_versions[host] = response_dict
         return response_dict
 
     @staticmethod


### PR DESCRIPTION
Builds on top of #82 (to avoid merge conflict in the context of added arguments), but in fact just impacts the `clone_update_project()` method, adding `uploadIntoClone=False` handling.

Tested with our local scripts that upload our SBOMs into:
* same project (dev branch tip)
* new instance of same release trail (different patch levels) - this one previously made a clone, updated its version and uploaded an SBOM, and de-activated the obsoleted original project instance; now it always updates the original instance and the clones are just snapshots
* new release branches (uploads SBOM into the cloned project, made from recent dev branch)

For certain life-cycles, this helps avoids a few problems seen with earlier approach internally:
* editing of the vulnerability data in a most-recent project instance (dev project, specific release trail) can end up forgetting the results of manual labor, because while the team member edits the entries, a new CI build clones the project and promotes the clone as the new iteration, and in effect supplants the project uuid that the team is editing. Future clones would happen from that new clone, so manually assigned verdicts saved into the now-old project uuid would not be seen and replicated.
* on DT server side, clone creation is currently "lossy" (there are options to copy information associated with the project when cloning it, but the list of such options grows from release to release and so far does not cover "everything"); with the project uuid associated with the tip of development, all relevant data should remain accessible (and older iterations are more of historic/support interest than a treasure to save in a vault, at least for this use-case where this new option is useful)